### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/web_based_automation.py
+++ b/web_based_automation.py
@@ -126,7 +126,7 @@ class WhatsAppMessenger:
             message_box.send_keys(Keys.RETURN)
             logging.info(f"Message sent to {phone_number}")
         except Exception as e:
-            logging.error(f"Error sending message to {phone_number}: {str(e)}")
+            logging.error(f"Error sending message: {str(e)}")
             raise MessageSendError(f"Failed to send message to {phone_number}")
 
     def _send_bulk_messages(self, message_collection):


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/8](https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/8)

To fix the problem, we should avoid logging sensitive information such as phone numbers in clear text. Instead, we can log a generic message that does not include the sensitive data. This way, we still get useful logging information without exposing sensitive details.

The best way to fix this issue is to modify the logging statements to exclude the phone number. We can replace the phone number with a generic placeholder or simply omit it from the log message. This change should be made in the `_send_message` method where the logging occurs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
