### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/web_based_automation.py
+++ b/web_based_automation.py
@@ -101,8 +101,9 @@ class WhatsAppMessenger:
             logging.info("Validating phone numbers.")
             for phone in phone_numbers:
                 if not phone.startswith('+') or len(phone) < 10:
-                    logging.error(f"Invalid phone number: {phone}")
-                    raise InvalidPhoneNumberError(f"Invalid phone number: {phone}")
+                    masked_phone = self._mask_phone_number(phone)
+                    logging.error(f"Invalid phone number: {masked_phone}")
+                    raise InvalidPhoneNumberError(f"Invalid phone number: {masked_phone}")
             logging.info("Phone numbers validated successfully.")
         except InvalidPhoneNumberError as e:
             logging.error(f"Validation failed: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/5](https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/5)

To fix the problem, we need to ensure that sensitive information, such as phone numbers, is not logged in clear text. Instead, we can mask the phone number before logging it. This can be done by creating a helper function to mask the phone number and using this function whenever we need to log a phone number.

The best way to fix the problem without changing existing functionality is to replace the direct logging of the phone number with a masked version of the phone number. We will use the existing `_mask_phone_number` method to achieve this.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
