### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/detection_based_automation.py
+++ b/detection_based_automation.py
@@ -73,7 +73,8 @@ class WhatsAppMessenger:
     def _send_message(self, phone_number, message):
         """Send message using pywhatkit."""
         try:
-            logging.info(f"Preparing to send message to {phone_number}")
+            masked_phone_number = phone_number[:3] + "****" + phone_number[-3:]
+            logging.info(f"Preparing to send message to {masked_phone_number}")
             if isinstance(message, str):
                 kit.sendwhatmsg(phone_number, message, datetime.now().hour, datetime.now().minute + 2)
             elif isinstance(message, tuple) and len(message) == 2:  # Image and message
@@ -82,9 +83,9 @@ class WhatsAppMessenger:
                 kit.sendwhats_image(phone_number, image_path, text)
             else:
                 raise MessageSendError("Invalid message format.")
-            logging.info(f"Message sent to {phone_number}")
+            logging.info(f"Message sent to {masked_phone_number}")
         except Exception as e:
-            logging.error(f"Error sending message to {phone_number}: {str(e)}")
+            logging.error(f"Error sending message to {masked_phone_number}: {str(e)}")
             raise MessageSendError(f"Failed to send message to {phone_number}")
 
     def _send_bulk_messages(self, message_collection):


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/2](https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/2)

To fix the problem, we should avoid logging sensitive information such as phone numbers in clear text. Instead, we can log a masked version of the phone number or omit it entirely from the logs. This way, we can still have useful log entries without exposing sensitive data.

The best way to fix the problem without changing existing functionality is to mask the phone number before logging it. We can replace the middle digits of the phone number with asterisks, leaving only the first and last few digits visible. This approach ensures that the logs remain informative while protecting sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
