### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/detection_based_automation.py
+++ b/detection_based_automation.py
@@ -73,7 +73,8 @@ class WhatsAppMessenger:
     def _send_message(self, phone_number, message):
         """Send message using pywhatkit."""
         try:
-            logging.info(f"Preparing to send message to {phone_number}")
+            masked_phone_number = phone_number[:3] + "****" + phone_number[-3:]
+            logging.info(f"Preparing to send message to {masked_phone_number}")
             if isinstance(message, str):
                 kit.sendwhatmsg(phone_number, message, datetime.now().hour, datetime.now().minute + 2)
             elif isinstance(message, tuple) and len(message) == 2:  # Image and message
@@ -82,9 +83,9 @@ class WhatsAppMessenger:
                 kit.sendwhats_image(phone_number, image_path, text)
             else:
                 raise MessageSendError("Invalid message format.")
-            logging.info(f"Message sent to {phone_number}")
+            logging.info(f"Message sent to {masked_phone_number}")
         except Exception as e:
-            logging.error(f"Error sending message to {phone_number}: {str(e)}")
+            logging.error(f"Error sending message to {masked_phone_number}: {str(e)}")
             raise MessageSendError(f"Failed to send message to {phone_number}")
 
     def _send_bulk_messages(self, message_collection):


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/3](https://github.com/kavineksith/WhatsAppAutomation/security/code-scanning/3)

To fix the problem, we should avoid logging the phone numbers directly. Instead, we can log a masked version of the phone number or use a unique identifier that does not reveal the actual phone number. This way, we can still have useful logs for debugging and operational purposes without exposing sensitive information.

We will modify the logging statements to mask the phone numbers. Specifically, we will replace the middle digits of the phone number with asterisks, leaving only the first and last few digits visible. This approach ensures that the phone number is not exposed in clear text while still providing enough information to identify the log entry.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
